### PR TITLE
removing rubocop from rakefile to avoid blocking coveralls report from CLI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'rspec'
 gem 'capybara'
 gem 'coveralls', require: false
 gem 'rubocop'
+gem 'reek'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,12 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rainbow (2.0.0)
+    rake (10.4.2)
+    reek (1.3.8)
+      rainbow (>= 1.99, < 3.0)
+      ruby2ruby (>= 2.0.8, < 3.0)
+      ruby_parser (~> 3.3)
+      sexp_processor
     rest-client (1.7.2)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
@@ -54,6 +60,12 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
     ruby-progressbar (1.7.5)
+    ruby2ruby (2.1.3)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.6.3)
+      sexp_processor (~> 4.1)
+    sexp_processor (4.4.4)
     simplecov (0.9.1)
       docile (~> 1.1.0)
       multi_json (~> 1.0)
@@ -72,6 +84,8 @@ PLATFORMS
 DEPENDENCIES
   capybara
   coveralls
+  rake
+  reek
   rspec
   rubocop
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
-require 'rubocop/rake_task'
 require 'rspec/core/rake_task'
 
-RuboCop::RakeTask.new :cop
 RSpec::Core::RakeTask.new :spec
 
-task default: [:cop, :spec]
+task default: [:spec]


### PR DESCRIPTION
fixes #237 