### PR TITLE
airport-challenge

### DIFF
--- a/lib/airport.rb
+++ b/lib/airport.rb
@@ -1,0 +1,9 @@
+class Airport
+
+  attr_reader :capacity
+
+  def initialize
+    @capacity = 1
+  end
+
+end

--- a/spec/airport_spec.rb
+++ b/spec/airport_spec.rb
@@ -1,0 +1,14 @@
+require 'airport'
+
+RSpec.describe Airport do
+
+airport = Airport.new
+
+  describe Airport do
+    it 'should assign a default capacity' do
+      expect(airport.capacity).to eq 1
+
+    end
+  end
+
+end


### PR DESCRIPTION
User stories included - to prevent landing when the airport is full, assign a default capacity.

The rest is incomplete.